### PR TITLE
Increase open files limit for thanos-store

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,7 @@ thanos_query_grpc_listen_port: "19182"
 thanos_query_grpc_listen_address: "0.0.0.0:{{ thanos_query_grpc_listen_port }}"
 thanos_store_grpc_listen_port: "19183"
 thanos_store_grpc_listen_address: "0.0.0.0:{{ thanos_store_grpc_listen_port }}"
+thanos_store_open_files_limit: 8192
 
 thanos_web_prometheus_url: 'http://localhost:9090/'
 

--- a/templates/thanos-store.service.j2
+++ b/templates/thanos-store.service.j2
@@ -9,6 +9,7 @@ User={{ thanos_user }}
 Group={{ thanos_group }}
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStart={{ thanos_bin_dir }}/thanos store {{ thanos_store_flags }}
+LimitNOFILE={{ thanos_store_open_files_limit }}
 
 SyslogIdentifier=thanos-store
 Restart=always


### PR DESCRIPTION
Upon startup, thanos-store takes a long time because it keeps hitting the default 1024 limit. Here's a selection of log messages:
```
Jun 11 18:19:14 metrics-0-ue1b thanos-store[9691]: {"caller":"bucket.go:458","err":"open /var/lib/prometheus/thanos-store/store: too many open files","level":"warn","msg":"failed to remove block we cannot load","ts":"2020-06-11T18:19:14.664432356Z"}
Jun 11 18:19:15 metrics-0-ue1b thanos-store[9691]: {"caller":"bucket.go:458","err":"openfdat /var/lib/prometheus/thanos-store/store/01DR2BG24HCRRC1JFX2QKCNYM1: too many open files","level":"warn","msg":"failed to remove block we cannot load","ts":"2020-06-11T18:19:15.784690749Z"}
Jun 11 18:24:17 metrics-0-ue1b thanos-store[9691]: {"caller":"bucket.go:460","elapsed":"1m39.894698261s","err":"create index header reader: write index header: new index reader: get TOC from object storage of 01DYTMWE8F32Q7D9DDJFYG2609/index: Get https://ird-prometheus-long-term-storage.s3.dualstack.us-east-1.amazonaws.com/01DYTMWE8F32Q7D9DDJFYG2609/index: dial tcp: lookup ird-prometheus-long-term-storage.s3.dualstack.us-east-1.amazonaws.com on 127.0.0.53:53: dial udp 127.0.0.53:53: socket: too many open files","id":"01DYTMWE8F32Q7D9DDJFYG2609","level":"warn","msg":"loading block failed","ts":"2020-06-11T18:24:17.72967532Z"}
```

Eventually, the gRPC listener starts up on TCP/19183 and things proceed to behave pretty normally. In my usage, I see the open files get up to about ~5600 before that happens now.